### PR TITLE
Implementing automatic calling of commonProcess().

### DIFF
--- a/src/Controller/Component/PrgComponent.php
+++ b/src/Controller/Component/PrgComponent.php
@@ -74,7 +74,8 @@ class PrgComponent extends Component {
 			'action' => null,
 			'tableMethod' => 'validateSearch',
 			'allowedParams' => [],
-			'filterEmpty' => false
+			'filterEmpty' => false,
+			'autoProcess' => false
 		],
 		'presetForm' => [
 			'table' => null,
@@ -128,6 +129,28 @@ class PrgComponent extends Component {
 				$field['field'] = $key;
 			}
 			$this->controller->presetVars[$key] = $field;
+		}
+		$this->autoProcess();
+	}
+
+/**
+ * Automatic commmon processing of the request.
+ *
+ * @return void
+ */
+	public function autoProcess() {
+		$autoProcess = $this->_config['commonProcess']['autoProcess'];
+		if ($autoProcess === false) {
+			return;
+		}
+		if ($autoProcess === true) {
+			$this->commonProcess();
+		}
+		if (is_array($autoProcess)) {
+			$action = $this->controller->request->action;
+			if (isset($autoProcess[$action])) {
+				$this->commonProcess($autoProcess[$action][0], $autoProcess[$action][1]);
+			}
 		}
 	}
 


### PR DESCRIPTION
This change allows it to configure the component to automatically trigger commonProcess() in the beforeFilter. I've set the default to false by default but I think it should be in fact set to true because I don't see any bad side effects it could have. Also I've made it so that instead of just activating it you can specify an action it should be triggered on and pass both params to the commmonProcess().